### PR TITLE
fix #14: Http response should use readString instead to avoid crash

### DIFF
--- a/ios/CustomHttp.swift
+++ b/ios/CustomHttp.swift
@@ -39,8 +39,8 @@ import NIOSSL
       let response = try await HTTPClient.shared.execute(request, timeout: .seconds(30))
       if response.status == .ok {
         let body = response.body
-        let collectedBytes = try await body.collect(upTo: 1024 * 1024 * 30)
-        let responseString = collectedBytes.getString(at: 0, length: collectedBytes.readableBytes)!
+        var collectedBytes = try await body.collect(upTo: 1024 * 1024 * 30)
+        let responseString = collectedBytes.readString(length: collectedBytes.readableBytes)!
         print("Response String: \(responseString)")
         resolve(responseString)
       } else {


### PR DESCRIPTION
Currently, we use collectedBytes.getString in CustomHttp to retrieve the response string; however, sometimes the collectedBytes will have _readerIndex set to a non-zero value, which causes the nil return and app crashes.

<img width="285" alt="Screenshot 2025-06-28 at 15 06 35" src="https://github.com/user-attachments/assets/3101bb4f-0390-4265-bb35-8295247c7620" />


It happens on some large bundle packages, such as [Japan eSIM Daypass from BillionConnect](https://www.billionconnect.net/pages/skuDetail/skuDetail?productId=491&name=Japan-eSIM-Daypass) (this eSIM product is only available from a non-Japanese IP address), which has a 46KB bundle package. My friend @Maxpicca-Li and I are also facing the same issue when travelling to Japan using such an eSIM, but we finally resolved it using another LPA application.

After reading the document, it seems that we should use readString instead of getString to avoid this issue. Hinted by: @dramforever

Finally, I recompiled the code and tested it on my iPhone with USB-C Reader + 9eSIM. I brought a 1-day eSIM with minimum Data to test (cost 0.97 USD), everything works fine!