### PR TITLE
Install with yarn in CI so the lockfile is respected

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,8 +25,15 @@ jobs:
         with:
           node-version: '20'
 
+      # This is a Yarn 3 project with a committed yarn.lock. Installing with npm
+      # ignored that lockfile and re-resolved every range, which is what broke
+      # the build: reanimated ^4.2.0 and worklets ^0.7.0 resolved to 4.5.3 and
+      # 0.7.4, a pairing reanimated rejects ("Please install Worklets 0.10.x or
+      # newer"), while the lockfile pins the compatible 4.2.0 / 0.7.1.
       - name: Install dependencies
-        run: npm install --legacy-peer-deps
+        run: |
+          corepack enable
+          yarn install --immutable
 
       - name: Extract version from package.json
         id: extract_version


### PR DESCRIPTION
The Android build has been failing on master for a while:

```
[Reanimated] Your installed version of Worklets (0.7.4) is not compatible with
installed version of Reanimated (4.5.3). Please install Worklets 0.10.x or newer.
```

This is a Yarn 3 project with a committed `yarn.lock` pinning reanimated **4.2.0** and worklets **0.7.1**, which are compatible. CI installed with `npm install --legacy-peer-deps`, which ignores that lockfile and re-resolves every range, so `^4.2.0` and `^0.7.0` drifted to 4.5.3 and 0.7.4 — a pairing reanimated rejects.

Nothing about the app changed; the builds simply were not reproducible. `yarn install --immutable` uses the pinned versions and fails loudly if `yarn.lock` and `package.json` ever diverge.

Verified locally: `yarn install --immutable` completes clean against the current lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)